### PR TITLE
minor punctuation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Try out new system prompts on your existing AI conversations. Over and over until you're happy.
 
-The `promptcraft` CLI let's you replay a conversation between a user and an AI assistant, but with a new system prompt.
+The `promptcraft` CLI lets you replay a conversation between a user and an AI assistant, but with a new system prompt.
 
 Conversations are stored in YAML files that look like:
 


### PR DESCRIPTION
The reason for the change _might_ be obvious, but just in case it's not immediately obvious, here's the _slightly verbose_ explanation:

"Let's" (with an apostrophe) means "let us".  For example, "let's eat pizza" or "let's write a cool Ruby app using this awesome gem from Dr. Nic".  

"Lets" on the other hand (without the apostrophe) is the verb "to let" conjugated for the third person singular.

- I let the dog sit on my bed.
- You let the dog sit on your bed.
- He _lets_ the dog sit on his bed.