### PR TITLE
Select provider based on environment variables and support --api-key option

### DIFF
--- a/lib/promptcraft/cli/run_command.rb
+++ b/lib/promptcraft/cli/run_command.rb
@@ -57,6 +57,11 @@ class Promptcraft::Cli::RunCommand
     desc "Provider name to use for chat completion"
   end
 
+  option :api_key do
+    long "--api-key api_key"
+    desc "API key for the provider"
+  end
+
   option :format do
     short "-f"
     long "--format format"
@@ -139,8 +144,8 @@ class Promptcraft::Cli::RunCommand
       conversations.each do |conversation|
         pool.post do
           # warn "Post processing conversation for #{conversation.messages.inspect}"
-          llm = if params[:provider]
-            Promptcraft::Llm.new(provider: params[:provider], model: params[:model])
+          llm = if params[:provider] && params[:api_key]
+            Promptcraft::Llm.new(provider: params[:provider], model: params[:model], api_key: params[:api_key])
           elsif conversation.llm
             conversation.llm
           else


### PR DESCRIPTION
Related to #16

Implements provider selection based on environment variables and introduces `--api-key` command-line option.

- **Provider Selection Logic**: Modifies `Promptcraft::Llm#initialize` to automatically select the provider based on the presence of specific environment variables (`GROQ_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`) in a prioritized order. If an `api_key` is explicitly provided, it defaults to using `openai` as the provider.
- **Error Handling**: Adds a condition to raise an error if no valid API key is found for any provider, ensuring the application does not proceed without necessary authentication details.
- **Command-Line Enhancements**: Introduces an `--api-key` option in `lib/promptcraft/cli/run_command.rb`, allowing users to specify an API key directly via the command line when a provider is also specified. This change facilitates easier and more flexible configuration of the tool.
- **API Key Parameter Support**: Adjusts the `run` method to pass the `api_key` option to `Promptcraft::Llm` if both `api_key` and `provider` options are provided, enabling dynamic provider authentication based on user input.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/drnic/promptcraft/issues/16?shareId=07521f24-fb58-4988-9a6c-583b76ff0d1d).